### PR TITLE
Change encoding to UTF-8

### DIFF
--- a/hangouts_parser.py
+++ b/hangouts_parser.py
@@ -22,7 +22,7 @@ class HangoutsParser:
         """
         conversations = []
         self_gaia_id = None  # gaia_id for the phone owner
-        with open(hangouts_file_name, 'rt') as data_file:
+        with open(hangouts_file_name, 'rt', encoding='utf-8') as data_file:
             # Read the Hangouts JSON file and turn into objects
             data = json.load(data_file, object_hook=lambda d: Namespace(**d))
             # Iterate through each conversation in the listi


### PR DESCRIPTION
Addressing adein/hangouts_to_sms#15, changing the open to UTF-8 encoding to allow for basic emoji characters (and other characters).

I believe adein/hangouts_to_sms#15 only effected Windows users (as the `open` command would default to using `cp1215` encoding instead of `utf-8`), but the addition of the encoding generally makes the code more robust IMO.